### PR TITLE
fix(apm-cli): correct class name from AwdCli to ApmCli

### DIFF
--- a/Formula/apm-cli.rb
+++ b/Formula/apm-cli.rb
@@ -1,4 +1,4 @@
-class AwdCli < Formula
+class ApmCli < Formula
   desc "Agent Primitives Manager (APM): The NPM for AI-Native Development"
   homepage "https://github.com/danielmeppiel/apm-cli"
   version "0.4.1"

--- a/Formula/apm-cli.rb.template
+++ b/Formula/apm-cli.rb.template
@@ -1,4 +1,4 @@
-class AwdCli < Formula
+class ApmCli < Formula
   desc "Agent Primitives Manager (APM): The NPM for AI-Native Development"
   homepage "https://github.com/danielmeppiel/apm-cli"
   version "{{VERSION}}"


### PR DESCRIPTION
This PR fixes the Homebrew formula template for apm-cli.rb.

#3 